### PR TITLE
Fix runtime mode

### DIFF
--- a/app/api/hitters/route.ts
+++ b/app/api/hitters/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import OpenAI from "openai"
 import { db } from "@/lib/database"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 const openai = process.env.OPENAI_API_KEY
   ? new OpenAI({

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -11,7 +11,7 @@ import {
   type ParsedPlay,
 } from "@/lib/parse-utils"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 console.log("Parse API: Checking environment variables...")
 console.log("OPENAI_API_KEY exists:", !!process.env.OPENAI_API_KEY)

--- a/app/api/predict/route.ts
+++ b/app/api/predict/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import OpenAI from "openai"
 import { db } from "@/lib/database"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 const openai = process.env.OPENAI_API_KEY
   ? new OpenAI({

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { db } from "@/lib/database"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 export async function GET() {
   try {

--- a/app/api/test-openai/route.ts
+++ b/app/api/test-openai/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import OpenAI from "openai"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 export async function GET() {
   try {

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { db } from "@/lib/database"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 export async function GET() {
   try {


### PR DESCRIPTION
## Summary
- use `nodejs` runtime in all server routes

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npx next lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c42884e088331a46e770ff39a78d0